### PR TITLE
With --bam-fix, write real long cigar at CG tag

### DIFF
--- a/src/GenericReadWriter.h
+++ b/src/GenericReadWriter.h
@@ -83,9 +83,8 @@ public:
 		for (int i = 0; i < read->Calculated && mapped; ++i) {
 			bool mappedCurrent = !read->Alignments[i].skip;
 			if(Config.getBamCigarFix() && mappedCurrent) {
-				int const maxInBAM = 64000;
-				mappedCurrent = mappedCurrent && read->Alignments[i].cigarOpCount < maxInBAM;
-				if (!mappedCurrent) {
+				int const maxInBAM = 0x10000;
+				if (read->Alignments[i].cigarOpCount >= maxInBAM) {
 					Log.Message("Skipping alignment %d for %s: number of CIGAR operations %d > 64k.", i, read->name, read->Alignments[i].cigarOpCount);
 				}
 			}


### PR DESCRIPTION
When option `--bam-fix` is in use, this pull request moves the CIGAR string in its binary format to a `CG` tag and leaves a fake CIGAR `<readLength>S` at the original place. This treatment keeps the alignment information and makes tools that don't read CIGAR work properly (e.g. sorting, merging and flagstat). Existing tools that read CIGAR will effectively take this read as unmapped. Future tools, for example samtools and htsjdk compiled [here](http://lh3lh3.users.sourceforge.net/data/cigar-64k/), may be able to recognize the real CIGAR and move it back. For example, if you run `samtools view bam-fix.sam|less -S` with the version there, you will see the CIGAR coming back. This way, you won't lose alignments with `--bam-fix` and may be compatible with future tools.

The only caveat is that at the default stringency level, picard tools will report an error as there is only one soft clipping. Reducing the stringency level makes it work. This is actually a good thing, reminding users that they have long cigars that old tools may miss.

Minimap2 has a similar option `-L`, inspired by ngmlr's `--bam-fix`. Thanks for the idea.