### PR TITLE
support for aarch64

### DIFF
--- a/lib/Complete-Striped-Smith-Waterman-Library/src/ssw.c
+++ b/lib/Complete-Striped-Smith-Waterman-Library/src/ssw.c
@@ -35,7 +35,11 @@
  *
  */
 
+#if defined(__aarch64__)
+#include <SSE2NEON.h>
+#else
 #include <emmintrin.h>
+#endif
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/lib/Complete-Striped-Smith-Waterman-Library/src/ssw.h
+++ b/lib/Complete-Striped-Smith-Waterman-Library/src/ssw.h
@@ -14,7 +14,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#if defined(__aarch64__)
+#include <SSE2NEON.h>
+#else
 #include <emmintrin.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ConvexAlignFast.cpp
+++ b/src/ConvexAlignFast.cpp
@@ -8,7 +8,11 @@
 #include <string.h>
 #include <stdio.h>
 #include <algorithm>
+#if defined(__aarch64__)
+#include <SSE2NEON.h>
+#else
 #include <x86intrin.h>
+#endif
 
 #include "IConfig.h"
 

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -94,7 +94,7 @@ void LogToConsole(bool color, int lvl, char const * const title, char const * co
 
 	if (color)
 		SetConsoleColor((ConsoleColor) (Message + (lvl * 2)));
-	if (args != 0)
+	if (va_arg(args, char *) != 0)
 		vfprintf(stderr, s, args);
 	else
 		fprintf(stderr, "%s", s);


### PR DESCRIPTION
This is a fix for building on aarch64.
Use sse2neon to build on aarch64.
The built-in type of va_list in aarch64 is a structure.
I modified it to use va_arg.