### PR TITLE
Fix for "Signed Integer Overflow in MAPQ"

### DIFF
--- a/src/AlignmentBuffer.cpp
+++ b/src/AlignmentBuffer.cpp
@@ -1889,6 +1889,7 @@ int AlignmentBuffer::computeMappingQuality(Align const & alignment, int readLeng
 		mqCount += 1;
 	}
 //	verbose(1, true, "");
+	if (mqCount == 0) return 0;
 	verbose(1, true, "%d / %d = %d", mqSum, mqCount, (int) (mqSum * 1.0f / mqCount));
 	return (int) (mqSum * 1.0f / mqCount);
 


### PR DESCRIPTION
When some read doesn't map at all the MAPQ is a "Signed Integer".
SAM example of a aligned read that does not map:
"597843e1-50df-4887-ab2c-c78a4d9ac28d    2048    chrXV   638441  -2147483648     4870S25M2I7M1I3M1D14M1D7M1I19M101S ..."
The MAPQ in this case is -2147483648. This creates some problems for samtools. "[W::sam_read1_sam] Parse error at line YYYY"
This happens because "mqCount" is zero on return of method "AlignmentBuffer::computeMappingQuality"